### PR TITLE
Use external batch object

### DIFF
--- a/src/entercommand.js
+++ b/src/entercommand.js
@@ -19,9 +19,9 @@ export default class EnterCommand extends Command {
 	/**
 	 * @inheritDoc
 	 */
-	execute() {
+	execute(parameters = {}) {
 		const doc = this.editor.document;
-		const batch = doc.batch();
+		const batch = parameters.batch || doc.batch();
 
 		doc.enqueueChanges( () => {
 			enterBlock( this.editor.data, batch, doc.selection, doc.schema );


### PR DESCRIPTION
We should use external batch object when it is provided in command parameters if somebody wants to you use enter command as a part of another command.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes #000.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
